### PR TITLE
add send to galaxy button for bulk

### DIFF
--- a/ckanext/bulk/templates/ckanext_bulk/ajax_snippets/bulk_download_popover.html
+++ b/ckanext/bulk/templates/ckanext_bulk/ajax_snippets/bulk_download_popover.html
@@ -10,16 +10,8 @@
               data-module-url="{{ url }}">
     <i class="fa fa-download"></i>{{ _(' Bulk download (metadata and data)') }}
       </a>
-      {% if package_id and g.user %}
-      {% asset 'ckanext-bpatheme/galaxy-send-js' %}
-      <a href="#"
-         class="btn btn-default"
-         data-module="galaxy_send"
-         data-module-package-id="{{ package_id }}"
-         data-module-galaxy-url="{{ h.get_galaxy_url() }}">
-          <i class="fa fa-rocket"></i>{{ _(' Send to Galaxy Australia') }}
-      </a>
-      {% endif %}
-      </div>
+      {% block bulk_download_popover_additions %}
+      {% endblock %}
+  </div>
 </div>
 

--- a/ckanext/bulk/templates/ckanext_bulk/ajax_snippets/bulk_download_popover.html
+++ b/ckanext/bulk/templates/ckanext_bulk/ajax_snippets/bulk_download_popover.html
@@ -10,6 +10,16 @@
               data-module-url="{{ url }}">
     <i class="fa fa-download"></i>{{ _(' Bulk download (metadata and data)') }}
       </a>
+      {% if package_id and g.user %}
+      {% asset 'ckanext-bpatheme/galaxy-send-js' %}
+      <a href="#"
+         class="btn btn-default"
+         data-module="galaxy_send"
+         data-module-package-id="{{ package_id }}"
+         data-module-galaxy-url="{{ h.get_galaxy_url() }}">
+          <i class="fa fa-rocket"></i>{{ _(' Send to Galaxy Australia') }}
+      </a>
+      {% endif %}
       </div>
 </div>
 

--- a/ckanext/bulk/templates/ckanext_bulk/snippets/common_popover.html
+++ b/ckanext/bulk/templates/ckanext_bulk/snippets/common_popover.html
@@ -9,7 +9,7 @@
         {% set url = h.add_url_param(h.url_for('bulk.package_search_list'), new_params=request.params) %}
     {% endif %}
  	{% if c.userobj.sysadmin or calling_page == "package_read" or request.params.q or request.params.res_format or request.params.tags or request.params.sequence_data_type or request.params.cart %}
-      {{ h.snippet('ckanext_bulk/ajax_snippets/bulk_download_popover.html', url=url) }}
+      {{ h.snippet('ckanext_bulk/ajax_snippets/bulk_download_popover.html', url=url, package_id=(id if calling_page == "package_read" else None)) }}
     {% endif %}
 {% else %}
 <div class="bulkdl">


### PR DESCRIPTION
## Changes

- `bulk_download_popover.html` — "Send to Galaxy Australia" button (bundle mode)
- `common_popover.html` — passes package_id to the snippet when on a dataset page

## Related Pull requests
- https://github.com/BioplatformsAustralia/ckanext-bpatheme/pull/40
- https://github.com/BioplatformsAustralia/ckanext-oidc-pkce-bpa/pull/23
- https://github.com/BioplatformsAustralia/ckanext-drs/pull/2